### PR TITLE
fix typo in alerts panel

### DIFF
--- a/src/components/AlertsPanel.js
+++ b/src/components/AlertsPanel.js
@@ -17,7 +17,7 @@ export default class AlertsPanel extends Component {
                     </div>
                     <hr />
                     <div className="center">
-                        <p>You Don't have any alerts</p>
+                        <p>You don't have any alerts</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Fixes typo in alerts panel: 'You ~Don't~ ***don't*** have any notifications' 